### PR TITLE
Better list management

### DIFF
--- a/python/eson/decoder.py
+++ b/python/eson/decoder.py
@@ -10,23 +10,26 @@ def decode(encoded_data):
 
 
 def __decode_types(data):
-    if not isinstance(data, dict):
-        return data
-    # Decode a list correctly back to a list
-    is_list = '__eson-list__' in data
-    _data = dict()
-    if is_list:
-        _data = list()
-        data = data['__eson-list__']
-    for encoded_key, encoded_value in data.items():
-        key, value = __decode_type(encoded_key, encoded_value)
-        if isinstance(value, dict):
-            value = __decode_types(value)
-        if is_list:
-            _data.append(value)
-        else:
+    if isinstance(data, dict):
+        _data = dict()
+        for encoded_key, encoded_value in data.items():
+            key, value = __decode_type(encoded_key, encoded_value)
+            if isinstance(value, (dict, list)):
+                value = __decode_types(value)
+            if not key:
+                return value
             _data[key] = value
-    return _data
+        return _data            
+
+    if isinstance(data, list):
+        _data = list()
+        for value in data:
+            if isinstance(value, (dict, list)):
+                value = __decode_types(value)
+            _data.append(value)
+        return _data
+    
+    return data
 
 
 def __decode_type(encoded_key, encoded_value):

--- a/python/eson/encoder.py
+++ b/python/eson/encoder.py
@@ -18,6 +18,7 @@ def __encode_types(data):
             if isinstance(encoded_value, (dict, list)):
                 encoded_value = __encode_types(encoded_value)
             _data[encoded_key] = encoded_value
+        return _data
 
     if isinstance(data, list):
         _data = list()

--- a/python/eson/encoder.py
+++ b/python/eson/encoder.py
@@ -11,8 +11,8 @@ def encode(data, pretty=False):
 
 
 def __encode_types(data):
-    _data = dict()
     if isinstance(data, dict):
+        _data = dict()
         for key, value in data.items():
             encoded_key, encoded_value = __encode_type(key, value)
             if isinstance(encoded_value, (dict, list)):
@@ -20,8 +20,20 @@ def __encode_types(data):
             _data[encoded_key] = encoded_value
 
     if isinstance(data, list):
-        _data['__eson-list__'] = __encode_types(dict(enumerate(data)))
-    return _data
+        _data = list()
+        for value in data:
+            encoded_key, encoded_value = __encode_type("", value)
+            if isinstance(encoded_value, (dict, list)):
+                encoded_value = __encode_types(encoded_value)
+            if encoded_key:
+                _data.append({encoded_key: encoded_value})
+            else:
+                _data.append(encoded_value)
+        return _data
+    encoded_key, encoded_value = __encode_type("", data)
+    if encoded_key:
+        return {encoded_key: encoded_value}
+    return encoded_value
 
 
 def __encode_type(key, value):


### PR DESCRIPTION
### Previous behaviour:
Eson lists were stored as a dictionary with indexes as keys, this meant that in the end the order could not be guaranteed.

### New behaviour
Lists are kept as lists.
